### PR TITLE
Vita: enforce exact two-times integer screen scaling to eliminate pixel wobble.

### DIFF
--- a/src/fsdb_unix.cpp
+++ b/src/fsdb_unix.cpp
@@ -40,7 +40,7 @@ void fsdb_fill_file_attrs (a_inode *aino)
     			  | (S_IWUSR & statbuf.st_mode ? 0 : A_FIBF_WRITE)
     			  | (S_IRUSR & statbuf.st_mode ? 0 : A_FIBF_READ));
 
-#if defined(WIN32) || defined(ANDROIDSDL)
+#if defined(WIN32) || defined(ANDROIDSDL) || defined(__PSP2__)
     // Always give execute & read permission
     aino->amigaos_mode &= ~A_FIBF_EXECUTE;
     aino->amigaos_mode &= ~A_FIBF_READ;

--- a/src/gp2x/menu/menu.cpp
+++ b/src/gp2x/menu/menu.cpp
@@ -290,6 +290,9 @@ void text_flip(void)
 {
 	SDL_Delay(10);
 	SDL_BlitSurface(text_screen,NULL,prSDLScreen,NULL);	
+	//DEBUG
+	//SDL_FillRect(prSDLScreen,NULL,SDL_MapRGB(prSDLScreen->format, 255, 255, 255))
+
 	SDL_Flip(prSDLScreen);
 }
 

--- a/src/gp2x/menu/menu.cpp
+++ b/src/gp2x/menu/menu.cpp
@@ -289,10 +289,7 @@ void text_draw_background()
 void text_flip(void)
 {
 	SDL_Delay(10);
-	SDL_BlitSurface(text_screen,NULL,prSDLScreen,NULL);	
-	//DEBUG
-	//SDL_FillRect(prSDLScreen,NULL,SDL_MapRGB(prSDLScreen->format, 255, 255, 255))
-
+	SDL_BlitSurface(text_screen,NULL,prSDLScreen,NULL);		
 	SDL_Flip(prSDLScreen);
 }
 

--- a/src/gp2x/menu/menu.cpp
+++ b/src/gp2x/menu/menu.cpp
@@ -339,6 +339,31 @@ void init_kickstart()
 
 void init_text(int splash)
 {
+#ifdef __PSP2__
+	//Display menu always in 320*240 on Vita
+	if(prSDLScreen != NULL) {
+		SDL_FillRect(prSDLScreen,NULL,0);
+		SDL_Flip(prSDLScreen);
+		SDL_FreeSurface(prSDLScreen);
+	};	
+	prSDLScreen = SDL_SetVideoMode(320, 240, 16, SDL_HWSURFACE|SDL_DOUBLEBUF);
+	
+	float sh = (float) 480;
+	float sw = (float)320*((float)480/(float)240);
+	int x = (960-sw)/2;
+	int y = 0;
+		
+	SDL_SetVideoModeScaling(x, y, sw, sh);
+	printf("SDL_SetVideoModeScaling(%i, %i, %i, %i)\n", x, y, sw, sh);
+#elif PANDORA
+	setenv("SDL_OMAP_LAYER_SIZE","640x480",1);
+	setenv("SDL_OMAP_BORDER_CUT","0,0,0,30",1);
+	prSDLScreen = SDL_SetVideoMode(320, 270, 16, SDL_SWSURFACE|SDL_FULLSCREEN|SDL_DOUBLEBUF);
+#else
+	prSDLScreen = SDL_SetVideoMode(320, 240, 16, SDL_SWSURFACE|SDL_FULLSCREEN);
+#endif
+
+	
 	char fname[256];
 	
 	SDL_Surface *tmp;
@@ -347,6 +372,7 @@ void init_text(int splash)
 	{
 		text_screen=SDL_CreateRGBSurface(prSDLScreen->flags,prSDLScreen->w,prSDLScreen->h,prSDLScreen->format->BitsPerPixel,prSDLScreen->format->Rmask,prSDLScreen->format->Gmask,prSDLScreen->format->Bmask,prSDLScreen->format->Amask);
 		window_screen=SDL_CreateRGBSurface(prSDLScreen->flags,prSDLScreen->w,prSDLScreen->h,prSDLScreen->format->BitsPerPixel,prSDLScreen->format->Rmask,prSDLScreen->format->Gmask,prSDLScreen->format->Bmask,prSDLScreen->format->Amask);
+
 		tmp=SDL_LoadBMP(MENU_FILE_TEXT);
 		if (text_screen==NULL || tmp==NULL)
 			exit(-1);
@@ -445,6 +471,8 @@ void quit_text(void)
 	text_window_background = NULL;
 	SDL_FreeSurface(text_screen);
 	text_screen = NULL;
+	SDL_FreeSurface(window_screen);
+	window_screen = NULL;
 }
 
 void write_text_pos(int x, int y, char * str)

--- a/src/gp2x/menu/menu_config.cpp
+++ b/src/gp2x/menu/menu_config.cpp
@@ -1021,6 +1021,19 @@ int saveconfig(int general)
 
 void loadconfig(int general)
 {
+#ifdef __PSP2__
+//first time opening the screen on Vita, somehow this sets the max possible resolution,
+//so open it with 320*270. Even 800*600 would work, but only a width of 320 is supported by the current
+//drawing routines
+	int visibleAreaWidth_old = visibleAreaWidth;
+	int mainMenu_displayedLines_old = mainMenu_displayedLines;
+	visibleAreaWidth = 320;
+	mainMenu_displayedLines = 270;
+	update_display();
+	visibleAreaWidth=visibleAreaWidth_old;
+	mainMenu_displayedLines = mainMenu_displayedLines_old;
+#endif
+
     char path[300];
 
     if(general == 1) {

--- a/src/gp2x/menu/menu_helper.cpp
+++ b/src/gp2x/menu/menu_helper.cpp
@@ -146,9 +146,11 @@ void update_display()
 	}
 	prSDLScreen = SDL_SetVideoMode(visibleAreaWidth, mainMenu_displayedLines, 16, SDL_HWSURFACE|SDL_DOUBLEBUF);
 	printf("SDL_SetVideoMode(%i, %i, 16)\n", visibleAreaWidth, mainMenu_displayedLines);
-	int sh = 544;
-	int sw = (int)((float)visibleAreaWidth*((float)544/(float)mainMenu_displayedLines));
-	int x = (960-sw)/2;
+//	int sh = 540;
+	int sh = 2 * (int) mainMenu_displayedLines;
+// int sw = (int)((float)visibleAreaWidth*((float)540/(float)mainMenu_displayedLines));
+	int sw = 2 * (int) visibleAreaWidth;
+   int x = (960-sw)/2;
 	int y = 0;
 	SDL_SetVideoModeScaling(x, 0, sw, sh);
 	printf("SDL_SetVideoModeScaling(%i, %i, %i, %i)\n", x, y, sw, sh);

--- a/src/gp2x/menu/menu_helper.cpp
+++ b/src/gp2x/menu/menu_helper.cpp
@@ -40,7 +40,6 @@ int saveAdfDir()
 	return 1;
 }
 
-
 void extractFileName(char * str,char *buffer)
 {
 	char *p=str+strlen(str)-1;
@@ -146,10 +145,13 @@ void update_display()
 	}
 	prSDLScreen = SDL_SetVideoMode(visibleAreaWidth, mainMenu_displayedLines, 16, SDL_HWSURFACE|SDL_DOUBLEBUF);
 	printf("SDL_SetVideoMode(%i, %i, 16)\n", visibleAreaWidth, mainMenu_displayedLines);
-//	int sh = 540;
-	int sh = 2 * (int) mainMenu_displayedLines;
-// int sw = (int)((float)visibleAreaWidth*((float)540/(float)mainMenu_displayedLines));
-	int sw = 2 * (int) visibleAreaWidth;
+	//the commented out scaling fills the screen better 
+	//but looks horrible, due to the current lack of a good shader sharp bilinear scaler
+	//so stick with simple 2* point filtering for now.
+//	float sh = 544;
+	float sh = (float) (2 * mainMenu_displayedLines);
+// float sw = ((float)visibleAreaWidth*((float)544/(float)mainMenu_displayedLines));
+	float sw = (float) (2 * visibleAreaWidth);
    int x = (960-sw)/2;
 	int y = 0;
 	SDL_SetVideoModeScaling(x, 0, sw, sh);

--- a/src/gp2x/menu/menu_main.cpp
+++ b/src/gp2x/menu/menu_main.cpp
@@ -90,8 +90,6 @@ int current_drive=0;
 int lastCpuSpeed=600;
 int ntsc=0;
 
-extern SDL_Surface *prSDLScreen;
-
 static void adjustToWindow(char *str, char* buffer)
 {
 	if (strlen(str)<33) return;
@@ -748,33 +746,8 @@ SDL_ANDROID_SetScreenKeyboardShown(1);
 }
 
 static void raise_mainMenu()
-{
-#ifdef __PSP2__
-	if(prSDLScreen != NULL) {
-		SDL_FillRect(prSDLScreen,NULL,0);
-		SDL_Flip(prSDLScreen);
-		SDL_FreeSurface(prSDLScreen);
-	}
-	
-	//for some reason the max texture size is 320 by 240
-	prSDLScreen = SDL_SetVideoMode(320, 240, 16, SDL_HWSURFACE|SDL_DOUBLEBUF);
-	int sh = 480;
-	int sw = (float)320*((float)480/(float)240);
-	int x = (960-sw)/2;
-	int y = 0;		
-	SDL_SetVideoModeScaling(x, y, sw, sh);
-	printf("SDL_SetVideoModeScaling(%i, %i, %i, %i)\n", x, y, sw, sh);
-#elif PANDORA
-	setenv("SDL_OMAP_LAYER_SIZE","640x480",1);
-	setenv("SDL_OMAP_BORDER_CUT","0,0,0,30",1);
-	prSDLScreen = SDL_SetVideoMode(320, 270, 16, SDL_SWSURFACE|SDL_FULLSCREEN|SDL_DOUBLEBUF);
-#else
-	prSDLScreen = SDL_SetVideoMode(320, 240, 16, SDL_SWSURFACE|SDL_FULLSCREEN);
-#endif
-
-
+{	
 	int i;
-
 	text_draw_background();
 	text_flip();
 	for(i=0;i<10;i++)

--- a/src/gp2x/menu/menu_main.cpp
+++ b/src/gp2x/menu/menu_main.cpp
@@ -755,11 +755,13 @@ static void raise_mainMenu()
 		SDL_Flip(prSDLScreen);
 		SDL_FreeSurface(prSDLScreen);
 	}
+	
+	//for some reason the max texture size is 320 by 240
 	prSDLScreen = SDL_SetVideoMode(320, 240, 16, SDL_HWSURFACE|SDL_DOUBLEBUF);
 	int sh = 480;
 	int sw = (float)320*((float)480/(float)240);
 	int x = (960-sw)/2;
-	int y = 0;
+	int y = 0;		
 	SDL_SetVideoModeScaling(x, y, sw, sh);
 	printf("SDL_SetVideoModeScaling(%i, %i, %i, %i)\n", x, y, sw, sh);
 #elif PANDORA

--- a/src/gp2x/menu/menu_main.cpp
+++ b/src/gp2x/menu/menu_main.cpp
@@ -756,8 +756,8 @@ static void raise_mainMenu()
 		SDL_FreeSurface(prSDLScreen);
 	}
 	prSDLScreen = SDL_SetVideoMode(320, 240, 16, SDL_HWSURFACE|SDL_DOUBLEBUF);
-	int sh = 544;
-	int sw = (float)320*((float)544/(float)240);
+	int sh = 480;
+	int sw = (float)320*((float)480/(float)240);
 	int x = (960-sw)/2;
 	int y = 0;
 	SDL_SetVideoModeScaling(x, y, sw, sh);
@@ -769,6 +769,7 @@ static void raise_mainMenu()
 #else
 	prSDLScreen = SDL_SetVideoMode(320, 240, 16, SDL_SWSURFACE|SDL_FULLSCREEN);
 #endif
+
 
 	int i;
 
@@ -930,6 +931,7 @@ int run_mainMenu()
 
 	if (sound_rate != old_sound_rate || mainMenu_soundStereo != old_stereo)
 		init_sound();
-
+	
+	update_display();
 	return mainMenu_case;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -250,7 +250,8 @@ void real_main (int argc, char **argv)
 #endif
 		// Set everthing to default and clear HD settings
 		SetDefaultMenuSettings(1);
-    loadconfig (1);
+    
+     loadconfig (1);
     if (! graphics_setup ()) {
 		exit (1);
     }

--- a/src/sdlgfx.cpp
+++ b/src/sdlgfx.cpp
@@ -140,7 +140,7 @@ void flush_block ()
 		SDL_Delay(((next_synctime - start) - 1000) / 1000);
 #else
       usleep((next_synctime - start) - 1000);
-#endif
+#endif    
     SDL_Flip(prSDLScreen);
 	  last_synctime = read_processor_time();
     


### PR DESCRIPTION
VITA version changes:
- The displayed screen on Vita is now slightly smaller but the graphics are not distorted anymore. All pixels are the same size, due to exact doubling of pixel sizes.

- I fixed the file attributes on HD Dirs by enabling read and execute, the Amiga side can now read the files

- support for displayed lines >240 and <240