### PR TITLE
VITA: Analog mouse support, menu updates

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -30,8 +30,29 @@ F11 - change input method
 Please put kickstarts files in android/data/pandora.uae4all.sdl/kickstarts directory.
 Files must be named as kick13.rom kick20.rom kick31.rom
 
-VITA controls:
+Vita Controls:
 
-L+R+dpad up down - Change Screen vertical position
-Start - toggle between gp2x style mouse mode, joystick mode and stylus mode (stylus mode not working yet). Press multiple times to change behaviour between the three modes.
-Select - toggle menu
+A=square
+B=circle
+X=cross
+Y=triangle
+
+Vita controls:
+
+Select = toggle menu
+Start+dpad = move screen
+right analog stick = analog mouse (can switch this to left in menu)
+left analog stick = acts as amiga joystick
+
+Only when custom controls are off:
+L/R=mousebuttons
+R+Square = CTRL
+R+Circle = LALT
+R+Cross = HELP
+L+Square = left mouse
+L+Circle = right mouse
+R+dpad = arrow keys
+
+When custom mouse controls are on:
+Dpad = digital mouse
+Triangle = slow mouse down

--- a/src/custom.cpp
+++ b/src/custom.cpp
@@ -2092,7 +2092,7 @@ static _INLINE_ void mousehack_setdontcare (void)
 
     write_log ("Don't care mouse mode set\n");
     mousestate = dont_care_mouse;
-    lastspr0x = lastmx; lastspr0y = lastmy;
+    lastspr0x = lastmx/16; lastspr0y = lastmy/16;
     mstepx = defstepx; mstepy = defstepy;
 }
 
@@ -2114,16 +2114,16 @@ static _INLINE_ uae_u32 mousehack_helper (void)
     {
 	/* @@@ This isn't completely right, it doesn't deal with virtual
 	   screen sizes larger than physical very well.  */
-	if (lastmy >= PREFS_GFX_HEIGHT)
-	    lastmy = PREFS_GFX_HEIGHT - 1;
+	if (lastmy/16 >= PREFS_GFX_HEIGHT)
+	    lastmy = 16 * (PREFS_GFX_HEIGHT - 1);
 	if (lastmy < 0)
 	    lastmy = 0;
 	if (lastmx < 0)
 	    lastmx = 0;
-	if (lastmx >= PREFS_GFX_WIDTH)
-	    lastmx = PREFS_GFX_WIDTH - 1;
-	mouseypos = coord_native_to_amiga_y (lastmy) << 1;
-	mousexpos = coord_native_to_amiga_x (lastmx);
+	if (lastmx/16 >= PREFS_GFX_WIDTH)
+	    lastmx = 16 * (PREFS_GFX_WIDTH - 1);
+	mouseypos = coord_native_to_amiga_y (lastmy/16) << 1;
+	mousexpos = coord_native_to_amiga_x (lastmx/16);
     }
 
     switch (_68k_dreg (0)) {
@@ -2171,8 +2171,8 @@ static _INLINE_ void do_mouse_hack (void)
   switch (mousestate) 
   {
     case normal_mouse:
-	    diffx = lastmx - lastsampledmx;
-	    diffy = lastmy - lastsampledmy;
+	    diffx = lastmx/16 - lastsampledmx;
+	    diffy = lastmy/16 - lastsampledmy;
 	    if (!newmousecounters) 
 	    {
 	      if (diffx > 127) 
@@ -2190,10 +2190,10 @@ static _INLINE_ void do_mouse_hack (void)
 	    break;
 
     case dont_care_mouse:
-	    diffx = adjust (((lastmx - lastspr0x) * mstepx) >> 16);
-	    diffy = adjust (((lastmy - lastspr0y) * mstepy) >> 16);
-	    lastspr0x = lastmx; 
-	    lastspr0y = lastmy;
+	    diffx = adjust (((lastmx/16 - lastspr0x) * mstepx) >> 16);
+	    diffy = adjust (((lastmy/16 - lastspr0y) * mstepy) >> 16);
+	    lastspr0x = lastmx/16; 
+	    lastspr0y = lastmy/16;
 	    mouse_x += diffx;
 	    mouse_y += diffy;
 	    break;
@@ -2205,8 +2205,8 @@ static _INLINE_ void do_mouse_hack (void)
 	    if (sprvbfl && (sprvbfl-- > 1)) 
       {
         int stylusxpos, stylusypos;          
-	      stylusxpos = coord_native_to_amiga_x (lastmx);
-	      stylusypos = coord_native_to_amiga_y (lastmy) << 1;
+	      stylusxpos = coord_native_to_amiga_x (lastmx/16);
+	      stylusypos = coord_native_to_amiga_y (lastmy/16) << 1;
 	      if(stylusxpos != spr0x || stylusypos != spr0y)
         {
           diffx = (stylusxpos - spr0x);

--- a/src/gp2x/gp2x.cpp
+++ b/src/gp2x/gp2x.cpp
@@ -54,7 +54,7 @@ int flashLED;
 
 int gp2xMouseEmuOn=0;
 int gp2xButtonRemappingOn=0;
-#ifndef PANDORA
+#if !defined(PANDORA) && !defined(__PSP2__)
 int hasGp2xButtonRemapping=1;
 #endif
 int GFXVIDINFO_HEIGHT=240;

--- a/src/gp2x/menu/menu.cpp
+++ b/src/gp2x/menu/menu.cpp
@@ -356,6 +356,12 @@ void init_text(int splash)
 		
 	SDL_SetVideoModeScaling(x, y, sw, sh);
 	printf("init_text: SDL_SetVideoModeScaling(%i, %i, %i, %i)\n", x, y, (int)sw, (int)sh);
+	
+	//This requires a recent SDL-Vita branch SDL12 for example 
+   //https://github.com/rsn8887/SDL-Vita/tree/SDL12
+   //to compile
+	SDL_SetVideoModeBilinear(0);
+	
 #elif PANDORA
 	setenv("SDL_OMAP_LAYER_SIZE","640x480",1);
 	setenv("SDL_OMAP_BORDER_CUT","0,0,0,30",1);

--- a/src/gp2x/menu/menu_config.cpp
+++ b/src/gp2x/menu/menu_config.cpp
@@ -92,6 +92,9 @@ int visibleAreaWidth = 320;
 
 int saveMenu_n_savestate = 0;
 
+#ifdef __PSP2__
+int mainMenu_leftStickMouse = 0;
+#endif
 
 // The following params in use, but can't be changed with gui
 int mainMenu_autosave = DEFAULT_AUTOSAVE;
@@ -100,15 +103,15 @@ int mainMenu_button2 = GP2X_BUTTON_A;
 int mainMenu_autofireButton1 = GP2X_BUTTON_B;
 int mainMenu_jump = -1;
 
+#ifdef __PSP2__
+int mainMenu_shader = 5;
+#endif
+
 // The following params not in use, but stored to write them back to the config file
 int gp2xClockSpeed = -1;
 int mainMenu_scanlines = 0;
 int mainMenu_enableScreenshots = DEFAULT_ENABLESCREENSHOTS;
 int mainMenu_enableScripts = DEFAULT_ENABLESCRIPTS;
-
-#ifdef __PSP2__
-int mainMenu_shader = 0;
-#endif
 
 #ifdef ANDROIDSDL
 int mainMenu_onScreen = 1;
@@ -187,7 +190,6 @@ void SetDefaultMenuSettings(int general)
     mainMenu_CPU_speed = 0;
 
     mainMenu_cpuSpeed = 600;
-
     mainMenu_joyConf = 0;
     mainMenu_joyPort = 0;
     mainMenu_autofireRate = 8;
@@ -216,6 +218,11 @@ void SetDefaultMenuSettings(int general)
     mainMenu_ntsc = DEFAULT_NTSC;
     mainMenu_frameskip = 0;
     mainMenu_autofire = DEFAULT_AUTOFIRE;
+
+#ifdef __PSP2__
+    mainMenu_shader = 5;
+    mainMenu_leftStickMouse = 0;
+#endif
 
     // The following params can't be changed in gui
     skipintro = DEFAULT_SKIPINTRO;
@@ -801,6 +808,8 @@ int saveconfig(int general)
 #ifdef __PSP2__
     snprintf((char*)buffer, 255, "shader=%d\n",mainMenu_shader);
     fputs(buffer,f);
+    snprintf((char*)buffer, 255, "leftstickmouse=%d\n",mainMenu_leftStickMouse);
+    fputs(buffer,f);
 #endif
     snprintf((char*)buffer, 255, "showstatus=%d\n",mainMenu_showStatus);
     fputs(buffer,f);
@@ -1101,6 +1110,7 @@ void loadconfig(int general)
 #endif
 #ifdef __PSP2__
         fscanf(f,"shader=%d\n",&mainMenu_shader);
+        fscanf(f,"leftstickmouse=%d\n",&mainMenu_leftStickMouse);        
 #endif
         fscanf(f,"showstatus=%d\n",&mainMenu_showStatus);
         fscanf(f,"mousemultiplier=%d\n",&mainMenu_mouseMultiplier );

--- a/src/gp2x/menu/menu_config.h
+++ b/src/gp2x/menu/menu_config.h
@@ -102,3 +102,8 @@ extern int mainMenu_vsync;
 #endif
 extern char custom_kickrom[256];
 #endif
+
+#ifdef __PSP2__
+extern int mainMenu_leftStickMouse;
+extern int mainMenu_shader;
+#endif

--- a/src/gp2x/menu/menu_controls.cpp
+++ b/src/gp2x/menu/menu_controls.cpp
@@ -449,10 +449,11 @@ static int key_controlsMenu(int *c)
 	static int delay=0;
 	int left=0, right=0, up=0, down=0, hit0=0, hit1=0;
 	SDL_Event event;
+#ifndef __PSP2__	// this can be snappy on Vita no need to worry about touch
 	delay ++;
 	if (delay<5) return end;
 	delay=0;
-
+#endif
 	while (SDL_PollEvent(&event) > 0)
 	{
 		if (event.type == SDL_KEYDOWN)

--- a/src/gp2x/menu/menu_display.cpp
+++ b/src/gp2x/menu/menu_display.cpp
@@ -57,13 +57,27 @@ enum {
 	MENUDISPLAY_CUTRIGHT,
 	MENUDISPLAY_FRAMESKIP,
 	MENUDISPLAY_REFRESHRATE,
+#ifdef __PSP2__
+	MENUDISPLAY_SHADER,
+#endif
 	MENUDISPLAY_SOUND,
 	MENUDISPLAY_SNDRATE,
 	MENUDISPLAY_STEREO,
 	MENUDISPLAY_END
 };
 
-
+#ifdef __PSP2__
+enum {
+	SHADER_NONE = 0,
+	SHADER_LCD3X,
+	SHADER_AAA,
+	SHADER_SCALE2X,
+	SHADER_SHARP_BILINEAR,
+	SHADER_SHARP_BILINEAR_SIMPLE,
+	SHADER_FXAA,
+	NUM_SHADERS, //NUM_SHADERS - 1 is the max allowed number in mainMenu_shader
+};
+#endif
 
 static void draw_displayMenu(int c)
 {
@@ -83,7 +97,7 @@ static void draw_displayMenu(int c)
 	int bb=(b%6)/3;
 	SDL_Rect r;
 	extern SDL_Surface *text_screen;
-	char value[20]="";
+	char value[25]="";
 	r.x=80-64; r.y=0; r.w=110+64+64; r.h=240;
 
 	text_draw_background();
@@ -228,6 +242,43 @@ static void draw_displayMenu(int c)
 		write_text_inv(tabstop3+1,menuLine,"60Hz");
 	else
 		write_text(tabstop3+1,menuLine,"60Hz");
+#ifdef __PSP2__	
+	//Shader settings on Vita
+	//MENUDISPLAY_SHADER
+	menuLine+=2;
+	write_text(leftMargin,menuLine,"Shader");
+  
+  	switch (mainMenu_shader)
+  	{
+		case SHADER_NONE:
+			snprintf((char*)value, 25, "NONE (perfect 2x)");
+			break;
+		case SHADER_LCD3X:
+			snprintf((char*)value, 25, "LCD3X");
+			break;
+		case SHADER_SCALE2X:
+			snprintf((char*)value, 25, "SCALE2X");
+			break;
+		case SHADER_AAA:
+			snprintf((char*)value, 25, "AAA");
+			break;
+		case SHADER_SHARP_BILINEAR:
+			snprintf((char*)value, 25, "SHARP_BILINEAR");
+			break;
+		case SHADER_SHARP_BILINEAR_SIMPLE:
+			snprintf((char*)value, 25, "SHARP_BILINEAR_SIMPL");
+			break;
+		case SHADER_FXAA:
+			snprintf((char*)value, 25, "FXAA");
+			break;
+		default:
+			break;
+	}
+	if ((menuDisplay!=MENUDISPLAY_SHADER)||(bb))
+		write_text_inv(tabstop3-2,menuLine,value);
+	else
+		write_text(tabstop3-2,menuLine,value);
+#endif
 
 	menuLine++;
 	write_text(leftMargin,menuLine,text_str_display_separator);
@@ -479,6 +530,24 @@ static int key_displayMenu(int *c)
 			if ((left)||(right))
 					mainMenu_ntsc = !mainMenu_ntsc;
 			break;
+#ifdef __PSP2__ //shader choice on VITA
+				case MENUDISPLAY_SHADER:
+            if (left)
+				{
+					if (mainMenu_shader <= 0)
+						mainMenu_shader = 0;
+					else 
+						mainMenu_shader -= 1;
+				}
+				else if (right)
+				{
+					if (mainMenu_shader >= NUM_SHADERS-1)
+						mainMenu_shader = NUM_SHADERS-1;
+					else
+						mainMenu_shader +=1;
+				}
+				break;
+#endif			
 			
 		case MENUDISPLAY_SOUND:
 				if (left)

--- a/src/gp2x/menu/menu_helper.cpp
+++ b/src/gp2x/menu/menu_helper.cpp
@@ -155,26 +155,28 @@ void update_display() {
     int x;
     int y;
 
-    //is the sharp_bilinear_simple shader active?
-    if (mainMenu_shader == 5) 
+    //is a shader active?
+    if (mainMenu_shader != 0) 
     {
     	sh = 544;
       sw = ((float)visibleAreaWidth*((float)544/(float)mainMenu_displayedLines));
     	x = (960 - sw) / 2;
     	y = (544 - sh) / 2;
     	
-    	//This requires SDL-Vita branch SDL12 for example 
+    	//This requires a recent SDL-Vita branch SDL12 for example 
     	//https://github.com/rsn8887/SDL-Vita/tree/SDL12
     	//to compile
-   	SDL_SetVideoModeScalingBilinear(x, y, sw, sh);
+   	SDL_SetVideoModeScaling(x, y, sw, sh);
+   	SDL_SetVideoModeBilinear(1);
     }
-    else //otherwise do regular integer 2* scaling to ensure good picture quality
+    else //otherwise do regular integer 2* scaling without filtering to ensure good picture quality
     {
     	sh = (float) (2 * mainMenu_displayedLines);
     	sw = (float) (2 * visibleAreaWidth);
     	x = (960 - sw) / 2;
       y = (544 - sh) / 2;
       SDL_SetVideoModeScaling(x, y, sw, sh);
+      SDL_SetVideoModeBilinear(0);
 	 }    
 	 printf("update_display: SDL_SetVideoModeScaling(%i, %i, %i, %i)\n", x, y, (int)sw, (int)sh);
 

--- a/src/gp2x/menu/menu_misc.cpp
+++ b/src/gp2x/menu/menu_misc.cpp
@@ -61,6 +61,9 @@ enum {
 #ifdef PANDORA
 	MENUMISC_PANDORASPEED,
 #endif
+#ifdef __PSP2__
+	MENUMISC_LEFTSTICKMOUSE,
+#endif
 #ifdef ANDROIDSDL
 	MENUMISC_ONSCREEN,
 #endif
@@ -70,10 +73,27 @@ enum {
 	MENUMISC_STATUSLINE,
 	MENUMISC_MOUSEMULTIPLIER,
 	MENUMISC_STYLUSOFFSET,
+#ifdef __PSP2__
+	MENUMISC_SHADER,
+#else
 	MENUMISC_TAPDELAY,
+#endif
 	MENUMISC_END
 };
 
+#ifdef __PSP2__
+enum {
+	SHADER_NONE = 0,
+	SHADER_LCD3X,
+	SHADER_AAA,
+	SHADER_SCALE2X,
+	SHADER_SHARP_BILINEAR,
+	SHADER_SHARP_BILINEAR_SIMPLE,
+	SHADER_FXAA,
+	NUM_SHADERS, //NUM_SHADERS - 1 is the max allowed number in mainMenu_shader
+};
+#endif
+	
 static void draw_miscMenu(int c)
 {
 	int leftMargin=3;
@@ -93,6 +113,11 @@ static void draw_miscMenu(int c)
 	SDL_Rect r;
 	extern SDL_Surface *text_screen;
 	char cpuSpeed[8];
+
+#ifdef __PSP2__
+	char shaderName[25];
+#endif
+	
 	r.x=80-64; r.y=0; r.w=110+64+64; r.h=240;
 
 	text_draw_background();
@@ -191,6 +216,26 @@ static void draw_miscMenu(int c)
 		write_text(tabstop4-1,menuLine,cpuSpeed);
 	write_text(tabstop6-1,menuLine,"MHz");
 #endif
+#ifdef __PSP2__
+  // MENUMISC_LEFTSTICKMOUSE
+	menuLine+=2;
+	write_text(leftMargin,menuLine,"Mouse Control:");	
+	if (mainMenu_leftStickMouse==0)
+	{
+		if ((menuMisc!=MENUMISC_LEFTSTICKMOUSE)||(bb))
+			write_text_inv(tabstop4-1,menuLine,"Right Stick");
+		else
+			write_text(tabstop4-1,menuLine,"Right Stick  ");
+	}
+	else if (mainMenu_leftStickMouse==1) 
+	{
+		if ((menuMisc!=MENUMISC_LEFTSTICKMOUSE)||(bb))
+			write_text_inv(tabstop4-1,menuLine,"Left Stick");
+		else
+			write_text(tabstop4-1,menuLine,"Left Stick  ");
+	}
+#endif
+
 #ifdef ANDROIDSDL
   // MENUMISC_ONSCREEN
 	menuLine+=2;
@@ -348,7 +393,7 @@ static void draw_miscMenu(int c)
 		write_text_inv(tabstop9,menuLine,text_str_8px);
 	else
 		write_text(tabstop9,menuLine,text_str_8px);
-
+#ifndef __PSP2__	
 	// MENUMISC_TAPDELAY
 	menuLine+=2;
 	write_text(leftMargin,menuLine,text_str_tap_delay);
@@ -367,6 +412,43 @@ static void draw_miscMenu(int c)
 		write_text_inv(tabstop9,menuLine,text_str_none);
 	else
 		write_text(tabstop9,menuLine,text_str_none);
+#else
+	//Shader settings on Vita
+	//MENUMISC_SHADER
+	menuLine+=2;
+	write_text(leftMargin,menuLine,"Shader");
+  
+  	switch (mainMenu_shader)
+  	{
+		case SHADER_NONE:
+			snprintf((char*)shaderName, 25, "NONE (perfect 2*)");
+			break;
+		case SHADER_LCD3X:
+			snprintf((char*)shaderName, 25, "LCD3X");
+			break;
+		case SHADER_SCALE2X:
+			snprintf((char*)shaderName, 25, "SCALE2X");
+			break;
+		case SHADER_AAA:
+			snprintf((char*)shaderName, 25, "AAA");
+			break;
+		case SHADER_SHARP_BILINEAR:
+			snprintf((char*)shaderName, 25, "SHARP_BILINEAR");
+			break;
+		case SHADER_SHARP_BILINEAR_SIMPLE:
+			snprintf((char*)shaderName, 25, "SHARP_BILNEAR_SIMPLE");
+			break;
+		case SHADER_FXAA:
+			snprintf((char*)shaderName, 25, "FXAA");
+			break;
+		default:
+			break;
+	}
+	if ((menuMisc!=MENUMISC_SHADER)||(bb))
+		write_text_inv(tabstop3-2,menuLine,shaderName);
+	else
+		write_text(tabstop3-2,menuLine,shaderName);
+#endif
 
 	menuLine++;
 	write_text(leftMargin,menuLine,text_str_misc_separator);
@@ -496,6 +578,13 @@ static int key_miscMenu(int *c)
 					mainMenu_cpuSpeed+=10;
         break;
 #endif
+#ifdef __PSP2__
+      case MENUMISC_LEFTSTICKMOUSE:
+				if ((left)||(right))
+						mainMenu_leftStickMouse = !mainMenu_leftStickMouse;
+        break;
+#endif
+
 #ifdef ANDROIDSDL
 			case MENUMISC_ONSCREEN:
 				if ((left)||(right))
@@ -615,6 +704,24 @@ static int key_miscMenu(int *c)
 						mainMenu_stylusOffset = 0;
 				}
 				break;
+#ifdef __PSP2__ //shader choice on VITA
+				case MENUMISC_SHADER:
+            if (left)
+				{
+					if (mainMenu_shader <= 0)
+						mainMenu_shader = 0;
+					else 
+						mainMenu_shader -= 1;
+				}
+				else if (right)
+				{
+					if (mainMenu_shader >= NUM_SHADERS-1)
+						mainMenu_shader = NUM_SHADERS-1;
+					else
+						mainMenu_shader +=1;
+				}
+				break;
+#else
 			case MENUMISC_TAPDELAY:
 				if (left)
 				{
@@ -635,6 +742,7 @@ static int key_miscMenu(int *c)
 						mainMenu_tapDelay = 10;
 				}
 				break;
+#endif //__PSP2__
 		}
 	}
 

--- a/src/gp2x/menu/menu_misc.cpp
+++ b/src/gp2x/menu/menu_misc.cpp
@@ -73,26 +73,9 @@ enum {
 	MENUMISC_STATUSLINE,
 	MENUMISC_MOUSEMULTIPLIER,
 	MENUMISC_STYLUSOFFSET,
-#ifdef __PSP2__
-	MENUMISC_SHADER,
-#else
 	MENUMISC_TAPDELAY,
-#endif
 	MENUMISC_END
 };
-
-#ifdef __PSP2__
-enum {
-	SHADER_NONE = 0,
-	SHADER_LCD3X,
-	SHADER_AAA,
-	SHADER_SCALE2X,
-	SHADER_SHARP_BILINEAR,
-	SHADER_SHARP_BILINEAR_SIMPLE,
-	SHADER_FXAA,
-	NUM_SHADERS, //NUM_SHADERS - 1 is the max allowed number in mainMenu_shader
-};
-#endif
 	
 static void draw_miscMenu(int c)
 {
@@ -113,10 +96,6 @@ static void draw_miscMenu(int c)
 	SDL_Rect r;
 	extern SDL_Surface *text_screen;
 	char cpuSpeed[8];
-
-#ifdef __PSP2__
-	char shaderName[25];
-#endif
 	
 	r.x=80-64; r.y=0; r.w=110+64+64; r.h=240;
 
@@ -392,8 +371,7 @@ static void draw_miscMenu(int c)
 	if ((mainMenu_stylusOffset==16)&&((menuMisc!=MENUMISC_STYLUSOFFSET)||(bb)))
 		write_text_inv(tabstop9,menuLine,text_str_8px);
 	else
-		write_text(tabstop9,menuLine,text_str_8px);
-#ifndef __PSP2__	
+		write_text(tabstop9,menuLine,text_str_8px);	
 	// MENUMISC_TAPDELAY
 	menuLine+=2;
 	write_text(leftMargin,menuLine,text_str_tap_delay);
@@ -412,43 +390,6 @@ static void draw_miscMenu(int c)
 		write_text_inv(tabstop9,menuLine,text_str_none);
 	else
 		write_text(tabstop9,menuLine,text_str_none);
-#else
-	//Shader settings on Vita
-	//MENUMISC_SHADER
-	menuLine+=2;
-	write_text(leftMargin,menuLine,"Shader");
-  
-  	switch (mainMenu_shader)
-  	{
-		case SHADER_NONE:
-			snprintf((char*)shaderName, 25, "NONE (perfect 2*)");
-			break;
-		case SHADER_LCD3X:
-			snprintf((char*)shaderName, 25, "LCD3X");
-			break;
-		case SHADER_SCALE2X:
-			snprintf((char*)shaderName, 25, "SCALE2X");
-			break;
-		case SHADER_AAA:
-			snprintf((char*)shaderName, 25, "AAA");
-			break;
-		case SHADER_SHARP_BILINEAR:
-			snprintf((char*)shaderName, 25, "SHARP_BILINEAR");
-			break;
-		case SHADER_SHARP_BILINEAR_SIMPLE:
-			snprintf((char*)shaderName, 25, "SHARP_BILNEAR_SIMPLE");
-			break;
-		case SHADER_FXAA:
-			snprintf((char*)shaderName, 25, "FXAA");
-			break;
-		default:
-			break;
-	}
-	if ((menuMisc!=MENUMISC_SHADER)||(bb))
-		write_text_inv(tabstop3-2,menuLine,shaderName);
-	else
-		write_text(tabstop3-2,menuLine,shaderName);
-#endif
 
 	menuLine++;
 	write_text(leftMargin,menuLine,text_str_misc_separator);
@@ -704,24 +645,6 @@ static int key_miscMenu(int *c)
 						mainMenu_stylusOffset = 0;
 				}
 				break;
-#ifdef __PSP2__ //shader choice on VITA
-				case MENUMISC_SHADER:
-            if (left)
-				{
-					if (mainMenu_shader <= 0)
-						mainMenu_shader = 0;
-					else 
-						mainMenu_shader -= 1;
-				}
-				else if (right)
-				{
-					if (mainMenu_shader >= NUM_SHADERS-1)
-						mainMenu_shader = NUM_SHADERS-1;
-					else
-						mainMenu_shader +=1;
-				}
-				break;
-#else
 			case MENUMISC_TAPDELAY:
 				if (left)
 				{
@@ -742,7 +665,6 @@ static int key_miscMenu(int *c)
 						mainMenu_tapDelay = 10;
 				}
 				break;
-#endif //__PSP2__
 		}
 	}
 

--- a/src/od-joy.cpp
+++ b/src/od-joy.cpp
@@ -48,6 +48,13 @@ extern int triggerR;
 extern int buttonSelect;
 extern int buttonStart;
 #endif
+#ifdef __PSP2__
+extern int rAnalogX;
+extern int rAnalogY;
+extern int lAnalogX;
+extern int lAnalogY;
+extern int mainMenu_leftStickMouse;
+#endif
 
 extern char launchDir[300];
 bool switch_autofire=false;
@@ -98,8 +105,14 @@ void read_joystick(int nr, unsigned int *dir, int *button)
 #ifdef USE_UAE4ALL_VKBD
 	if (!vkbd_mode && ((mainMenu_customControls && mainMenu_custom_dpad==2) || gp2xMouseEmuOn || (triggerL && !triggerR && !gp2xButtonRemappingOn)))
 #else
+#ifdef __PSP2__
+	//on Vita, the L trigger is by default mapped to a mousebutton
+	//so remove the hard coded LTrigger here that was enabling the digital mouse
+	if (((mainMenu_customControls && mainMenu_custom_dpad==2) || gp2xMouseEmuOn))
+#else
 	if (((mainMenu_customControls && mainMenu_custom_dpad==2) || gp2xMouseEmuOn || (triggerL && !triggerR && !gp2xButtonRemappingOn)))
-#endif
+#endif __PSP2__
+#endif 
 	{
 		if (buttonY)
 			mouseScale = mainMenu_mouseMultiplier;
@@ -166,6 +179,41 @@ void read_joystick(int nr, unsigned int *dir, int *button)
 				top = 1;
 		}
 	}
+
+#ifdef __PSP2__
+	//VITA: always use an analog stick (default: right stick) for mouse pointer movements
+	//here we are using a small deadzone
+	int analogX;
+	int analogY;
+		
+	if (mainMenu_leftStickMouse) {
+		analogX=lAnalogX;
+		analogY=lAnalogY;
+	}
+	else 
+	{
+		analogX=rAnalogX;
+		analogY=rAnalogY;
+	}
+		
+	if (analogX<100 && analogX>-100) 
+	{
+		analogX=0;
+	}
+	if (analogY<100 && analogY>-100)
+	{
+		analogY=0;
+	}
+	if (analogX != 0 && analogY != 0 ) 
+	{
+		//max movement is mouseScale.
+		//that way, when in one of the other mouse modes, 
+		//the Y button to change scale still works
+		lastmx += (int) (analogX/32768.0f * mouseScale);
+		lastmy += (int) (analogY/32768.0f * mouseScale);
+		newmousecounters=1;
+	}
+#endif //__PSP2__
 
 #ifdef USE_UAE4ALL_VKBD
 	if(mainMenu_customControls && !vkbd_mode)

--- a/src/od-joy.cpp
+++ b/src/od-joy.cpp
@@ -209,8 +209,8 @@ void read_joystick(int nr, unsigned int *dir, int *button)
 		//max movement is mouseScale.
 		//that way, when in one of the other mouse modes, 
 		//the Y button to change scale still works
-		lastmx += (int) (analogX/32768.0f * mouseScale);
-		lastmy += (int) (analogY/32768.0f * mouseScale);
+		lastmx += (int) (analogX/32769.0f * mouseScale);
+		lastmy += (int) (analogY/32769.0f * mouseScale);
 		newmousecounters=1;
 	}
 #endif //__PSP2__

--- a/src/od-joy.cpp
+++ b/src/od-joy.cpp
@@ -98,8 +98,8 @@ void read_joystick(int nr, unsigned int *dir, int *button)
 }
 #endif
 */
-	int mouseScale = mainMenu_mouseMultiplier * 4;
-	if (mouseScale > 99)
+	int mouseScale = mainMenu_mouseMultiplier * 4 * 16;
+	if (mouseScale > (99*16))
 		mouseScale /= 100;
 
 #ifdef USE_UAE4ALL_VKBD
@@ -115,7 +115,7 @@ void read_joystick(int nr, unsigned int *dir, int *button)
 #endif 
 	{
 		if (buttonY)
-			mouseScale = mainMenu_mouseMultiplier;
+			mouseScale = mainMenu_mouseMultiplier * 16;
 #if defined(PANDORA) || defined(ANDROIDSDL)
 		if (dpadLeft)
 #else
@@ -204,7 +204,7 @@ void read_joystick(int nr, unsigned int *dir, int *button)
 	{
 		analogY=0;
 	}
-	if (analogX != 0 && analogY != 0 ) 
+	if (analogX != 0 || analogY != 0 ) 
 	{
 		//max movement is mouseScale.
 		//that way, when in one of the other mouse modes, 

--- a/src/sdlgfx.cpp
+++ b/src/sdlgfx.cpp
@@ -763,27 +763,27 @@ void handle_events (void)
 			mouse_state = true;
 			if(gp2xButtonRemappingOn)
 			{
-				lastmx = rEvent.motion.x*2 - mainMenu_stylusOffset + moved_x + stylusAdjustX >> 1;
-				lastmy = rEvent.motion.y*2 - mainMenu_stylusOffset + moved_y + stylusAdjustY >> 1;
+				lastmx = 16 * (rEvent.motion.x*2 - mainMenu_stylusOffset + moved_x + stylusAdjustX >> 1);
+				lastmy = 16 * (rEvent.motion.y*2 - mainMenu_stylusOffset + moved_y + stylusAdjustY >> 1);
 				//mouseMoving = 1;
 			}
 			else if(slow_mouse)
 			{
-				lastmx += rEvent.motion.xrel;
-				lastmy += rEvent.motion.yrel;
+				lastmx += 16 * rEvent.motion.xrel;
+				lastmy += 16 * rEvent.motion.yrel;
 				if(rEvent.motion.x == 0)
-					lastmx -= 2;
+					lastmx -= 2*16;
 				if(rEvent.motion.y == 0)
-					lastmy -= 2;
+					lastmy -= 2*16;
 				if(rEvent.motion.x == visibleAreaWidth-1)
-					lastmx += 2;
+					lastmx += 2*16;
 				if(rEvent.motion.y == mainMenu_displayedLines-1)
-					lastmy += 2;
+					lastmy += 2*16;
 			}
 			else
 			{
-				int mouseScale = mainMenu_mouseMultiplier * 4;
-				if (mouseScale > 99)
+				int mouseScale = mainMenu_mouseMultiplier * 4 *16;
+				if (mouseScale > 99*16)
 					mouseScale /= 100;
 
 				lastmx += rEvent.motion.xrel * mouseScale;

--- a/src/sdlgfx.cpp
+++ b/src/sdlgfx.cpp
@@ -157,6 +157,7 @@ void flush_block ()
 #ifndef __PSP2__
 	SDL_LockSurface (prSDLScreen);
 #endif
+#ifndef __PSP2__
 	if(stylusClickOverride)
 	{
 		justClicked = 0;
@@ -190,6 +191,7 @@ void flush_block ()
 			fcounter++;
 		}
 	}
+#endif __PSP2__
 	init_row_map();
 }
 
@@ -549,6 +551,7 @@ void handle_events (void)
 				}
 			}
 
+#ifndef __PSP2__ //Skip input mode cycling for Vita. The mouse is always available already and the stylus mode never worked. Also the start button is repurposed for screen moving.
 #ifdef ANDROIDSDL
 			if (rEvent.key.keysym.sym==SDLK_F11)
 #else
@@ -566,6 +569,7 @@ void handle_events (void)
 					// if specified:
 					// remapping mode (with whatever's been supplied)
 					// back to start of state
+					
 #ifndef PANDORA
 					if (!hasGp2xButtonRemapping)
 					{
@@ -598,7 +602,6 @@ void handle_events (void)
 #ifndef PANDORA
 					}
 #endif
-
 				show_inputmode = 1;
 				}
 			}
@@ -611,6 +614,7 @@ void handle_events (void)
 					break;
 			}
 #endif
+#endif //__PSP2__
 #ifndef PANDORA
 			if (gp2xButtonRemappingOn)
 #endif


### PR DESCRIPTION
Note: I allowed the user to disable bilinear filtering/shaders and go back to perfect 2x scaling without restarting UAE by selecting NONE as a shader. This required a small modification to Vita-SDL (see my pull request or fork). To compile you need my latest version with the function SDL_SetVideoModeBilinear(int enable_bilinear). That function replaces my old function SDL_SetVideoModeScalingBilinear. This is more logical and in-line with the SetSync option we use, too.

Complete changelog for this pull request:

- added analog mouse support with menu option to choose left or right stick for mouse control
- disabled broken gp2x stylus mode and mouse emu mode
- START does not switch input modes anymore (mouse is now always enabled)
- L/R are mouse buttons now
- screen movement switched from L+R+DPAD to START+DPAD
- new menu item in misc menu: select which analog stick to use for mouse
- new menu item in display menu: choose shader (default: sharp_bilinear_simple)
- none (perfect 2x) is also a possible shader choice. 
- custom controls menu is now more snappy and responsive