### PR TITLE
VITA: virtual keyboard, analog deadzone, quick resolution switching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ set(INC_FILES
         src/menu
         src/include
         src/gp2x/menu
+        src/vkbd
         )
 
 set(FLAGS
@@ -37,6 +38,8 @@ set(FLAGS
         -DUSE_SDL -DGCCCONSTFUNC="__attribute__\(\(const\)\)" -DUSE_UNDERSCORE
         -DSHM_SUPPORT_LINKS=0 -DUNALIGNED_PROFITABLE -DOPTIMIZED_FLAGS -DOS_WITHOUT_MEMORY_MANAGEMENT
         -DROM_PATH_PREFIX=\"ux0:/data/uae4all/roms/\" -DDATA_PREFIX=\"app0:/data/\" -DSAVE_PREFIX=\"ux0:/data/uae4all/saves/\"
+-DUSE_UAE4ALL_VKBD
+-DVKBD_ALWAYS
         -fomit-frame-pointer -Wno-unused -Wno-format
         -ffast-math -fstrict-aliasing -mstructure-size-boundary=32 -fexpensive-optimizations
         -fweb -frename-registers -fomit-frame-pointer

--- a/Readme.txt
+++ b/Readme.txt
@@ -32,15 +32,14 @@ Files must be named as kick13.rom kick20.rom kick31.rom
 
 Vita Controls:
 
-A=square
-B=circle
-X=cross
-Y=triangle
-
-Vita controls:
+square=A
+circle=B
+cross=X
+triangle=Y
 
 Select = toggle menu
-Start+dpad = move screen
+Start+dpad up/down = move screen up down
+Start+dpad left/right = change screenmode (to zoom in on games with borders)
 right analog stick = analog mouse (can switch this to left in menu)
 left analog stick = acts as amiga joystick
 

--- a/Readme.txt
+++ b/Readme.txt
@@ -38,12 +38,13 @@ cross=X
 triangle=Y
 
 Select = toggle menu
+Start + Select (in this order) = toggle virtual keyboard
 Start+dpad up/down = move screen up down
-Start+dpad left/right = change screenmode (to zoom in on games with borders)
+Start+dpad left/right = change screenmode (to zoom games with large black borders)
 right analog stick = analog mouse (can switch this to left in menu)
 left analog stick = acts as amiga joystick
 
-Only when custom controls are off:
+When custom controls are off:
 L/R=mousebuttons
 R+Square = CTRL
 R+Circle = LALT

--- a/src/gp2x/menu/menu_config.cpp
+++ b/src/gp2x/menu/menu_config.cpp
@@ -60,7 +60,11 @@ int mainMenu_CPU_speed = 0;
 int mainMenu_cpuSpeed = 600;
 
 int mainMenu_joyConf = 0;
+#ifdef __PSP2__
+int mainMenu_joyPort = 2; // Default to port 1 on Vita because mouse is always on.
+#else
 int mainMenu_joyPort = 0; // Both ports
+#endif
 int mainMenu_autofireRate = 8;
 int mainMenu_showStatus = DEFAULT_STATUSLN;
 int mainMenu_mouseMultiplier = DEFAULT_MOUSEMULTIPLIER;
@@ -95,7 +99,7 @@ int saveMenu_n_savestate = 0;
 #ifdef __PSP2__
 int mainMenu_shader = 5;
 int mainMenu_leftStickMouse = 0;
-int mainMenu_deadZone = 100;
+int mainMenu_deadZone = 1000;
 #endif
 
 // The following params in use, but can't be changed with gui
@@ -189,7 +193,11 @@ void SetDefaultMenuSettings(int general)
 
     mainMenu_cpuSpeed = 600;
     mainMenu_joyConf = 0;
+#ifdef __PSP2__
+    mainMenu_joyPort = 2; // Default to port 1 on Vita because mouse is always on.
+#else
     mainMenu_joyPort = 0;
+#endif
     mainMenu_autofireRate = 8;
     mainMenu_showStatus = DEFAULT_STATUSLN;
     mainMenu_mouseMultiplier = DEFAULT_MOUSEMULTIPLIER;
@@ -220,7 +228,7 @@ void SetDefaultMenuSettings(int general)
 #ifdef __PSP2__
     mainMenu_shader = 5;
     mainMenu_leftStickMouse = 0;
-    mainMenu_deadZone = 100;
+    mainMenu_deadZone = 1000;
 #endif
 
     // The following params can't be changed in gui

--- a/src/gp2x/menu/menu_config.cpp
+++ b/src/gp2x/menu/menu_config.cpp
@@ -93,7 +93,9 @@ int visibleAreaWidth = 320;
 int saveMenu_n_savestate = 0;
 
 #ifdef __PSP2__
+int mainMenu_shader = 5;
 int mainMenu_leftStickMouse = 0;
+int mainMenu_deadZone = 100;
 #endif
 
 // The following params in use, but can't be changed with gui
@@ -102,10 +104,6 @@ int mainMenu_button1 = GP2X_BUTTON_X;
 int mainMenu_button2 = GP2X_BUTTON_A;
 int mainMenu_autofireButton1 = GP2X_BUTTON_B;
 int mainMenu_jump = -1;
-
-#ifdef __PSP2__
-int mainMenu_shader = 5;
-#endif
 
 // The following params not in use, but stored to write them back to the config file
 int gp2xClockSpeed = -1;
@@ -222,6 +220,7 @@ void SetDefaultMenuSettings(int general)
 #ifdef __PSP2__
     mainMenu_shader = 5;
     mainMenu_leftStickMouse = 0;
+    mainMenu_deadZone = 100;
 #endif
 
     // The following params can't be changed in gui
@@ -810,6 +809,8 @@ int saveconfig(int general)
     fputs(buffer,f);
     snprintf((char*)buffer, 255, "leftstickmouse=%d\n",mainMenu_leftStickMouse);
     fputs(buffer,f);
+    snprintf((char*)buffer, 255, "deadzone=%d\n",mainMenu_deadZone);
+    fputs(buffer,f);
 #endif
     snprintf((char*)buffer, 255, "showstatus=%d\n",mainMenu_showStatus);
     fputs(buffer,f);
@@ -1110,7 +1111,8 @@ void loadconfig(int general)
 #endif
 #ifdef __PSP2__
         fscanf(f,"shader=%d\n",&mainMenu_shader);
-        fscanf(f,"leftstickmouse=%d\n",&mainMenu_leftStickMouse);        
+        fscanf(f,"leftstickmouse=%d\n",&mainMenu_leftStickMouse);
+        fscanf(f,"deadzone=%d\n",&mainMenu_deadZone);        
 #endif
         fscanf(f,"showstatus=%d\n",&mainMenu_showStatus);
         fscanf(f,"mousemultiplier=%d\n",&mainMenu_mouseMultiplier );

--- a/src/gp2x/menu/menu_config.h
+++ b/src/gp2x/menu/menu_config.h
@@ -106,4 +106,5 @@ extern char custom_kickrom[256];
 #ifdef __PSP2__
 extern int mainMenu_leftStickMouse;
 extern int mainMenu_shader;
+extern int mainMenu_deadZone;
 #endif

--- a/src/gp2x/menu/menu_controls.cpp
+++ b/src/gp2x/menu/menu_controls.cpp
@@ -391,7 +391,11 @@ static void draw_controlsMenu(int c)
 
 	// MENUCONTROLS_A
 	menuLine+=3;
+#ifdef __PSP2__
+	write_text(leftMargin,menuLine,"(Square)");
+#else
 	write_text(leftMargin,menuLine,"   (A)");
+#endif
 	getMapping(mainMenu_custom_A);
 	if ((menuControls!=MENUCONTROLS_A)||(bb))
 		write_text_inv(tabstop1-4,menuLine,mapping);
@@ -399,7 +403,11 @@ static void draw_controlsMenu(int c)
 		write_text(tabstop1-4,menuLine,mapping);
 	// MENUCONTROLS_B
 	menuLine+=2;
+#ifdef __PSP2__
+	write_text(leftMargin,menuLine,"(Circle)");
+#else
 	write_text(leftMargin,menuLine,"   (B)");
+#endif
 	getMapping(mainMenu_custom_B);
 	if ((menuControls!=MENUCONTROLS_B)||(bb))
 		write_text_inv(tabstop1-4,menuLine,mapping);
@@ -407,7 +415,11 @@ static void draw_controlsMenu(int c)
 		write_text(tabstop1-4,menuLine,mapping);
 	// MENUCONTROLS_X
 	menuLine+=2;
+#ifdef __PSP2__
+	write_text(leftMargin,menuLine,"(Cross)");
+#else
 	write_text(leftMargin,menuLine,"   (X)");
+#endif
 	getMapping(mainMenu_custom_X);
 	if ((menuControls!=MENUCONTROLS_X)||(bb))
 		write_text_inv(tabstop1-4,menuLine,mapping);
@@ -415,7 +427,11 @@ static void draw_controlsMenu(int c)
 		write_text(tabstop1-4,menuLine,mapping);
 	// MENUCONTROLS_Y
 	menuLine+=2;
+#ifdef __PSP2__
+	write_text(leftMargin,menuLine,"(Triangle)");
+#else
 	write_text(leftMargin,menuLine,"   (Y)");
+#endif
 	getMapping(mainMenu_custom_Y);
 	if ((menuControls!=MENUCONTROLS_Y)||(bb))
 		write_text_inv(tabstop1-4,menuLine,mapping);

--- a/src/gp2x/menu/menu_misc.cpp
+++ b/src/gp2x/menu/menu_misc.cpp
@@ -73,7 +73,11 @@ enum {
 	MENUMISC_STATUSLINE,
 	MENUMISC_MOUSEMULTIPLIER,
 	MENUMISC_STYLUSOFFSET,
+#ifdef __PSP2__
+	MENUMISC_DEADZONE,
+#else
 	MENUMISC_TAPDELAY,
+#endif
 	MENUMISC_END
 };
 	
@@ -371,7 +375,18 @@ static void draw_miscMenu(int c)
 	if ((mainMenu_stylusOffset==16)&&((menuMisc!=MENUMISC_STYLUSOFFSET)||(bb)))
 		write_text_inv(tabstop9,menuLine,text_str_8px);
 	else
-		write_text(tabstop9,menuLine,text_str_8px);	
+		write_text(tabstop9,menuLine,text_str_8px);
+#ifdef __PSP2__
+	//Analog Stick Deadzone settings on Vita
+	//MENUMISC_DEADZONE
+	menuLine+=2;
+	write_text(leftMargin,menuLine,"Mouse Deadzone");
+  	snprintf((char*)cpuSpeed, 8, "%d", mainMenu_deadZone);
+  	if ((menuMisc!=MENUMISC_DEADZONE)||(bb))
+		write_text_inv(tabstop3-2,menuLine,cpuSpeed);
+	else
+		write_text(tabstop3-2,menuLine,cpuSpeed);
+#else
 	// MENUMISC_TAPDELAY
 	menuLine+=2;
 	write_text(leftMargin,menuLine,text_str_tap_delay);
@@ -390,7 +405,7 @@ static void draw_miscMenu(int c)
 		write_text_inv(tabstop9,menuLine,text_str_none);
 	else
 		write_text(tabstop9,menuLine,text_str_none);
-
+#endif
 	menuLine++;
 	write_text(leftMargin,menuLine,text_str_misc_separator);
 	menuLine++;
@@ -645,6 +660,36 @@ static int key_miscMenu(int *c)
 						mainMenu_stylusOffset = 0;
 				}
 				break;
+#ifdef __PSP2__
+			case MENUMISC_DEADZONE:
+				if (left)
+				{
+					if (mainMenu_deadZone <= 0)
+						mainMenu_deadZone=0;
+					else if (mainMenu_deadZone >= 2000)
+						mainMenu_deadZone-=1000;
+					else if (mainMenu_deadZone >= 200)
+						mainMenu_deadZone-=100;
+					else if (mainMenu_deadZone >= 20)
+						mainMenu_deadZone-=10;
+					else if (mainMenu_deadZone >= 1)
+						mainMenu_deadZone-=1;
+				}
+				else if (right)
+				{
+					if (mainMenu_deadZone >= 10000)
+						mainMenu_deadZone=10000;
+					else if (mainMenu_deadZone>=1000)
+						mainMenu_deadZone+=1000;
+					else if (mainMenu_deadZone>=100)
+						mainMenu_deadZone+=100;
+					else if (mainMenu_deadZone>=10)
+						mainMenu_deadZone+=10;
+					else if (mainMenu_deadZone>=0)
+						mainMenu_deadZone+=1;
+				}
+				break;
+#else
 			case MENUMISC_TAPDELAY:
 				if (left)
 				{
@@ -665,6 +710,7 @@ static int key_miscMenu(int *c)
 						mainMenu_tapDelay = 10;
 				}
 				break;
+#endif
 		}
 	}
 

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -253,9 +253,11 @@ static void goMenu(void)
 	if (quit_program != 0)
 		return;
 	emulating=1;
+#ifndef __PSP2__ //no need to erase all the vkbd graphics from memory on Vita
 #ifdef USE_UAE4ALL_VKBD
 	vkbd_quit();
 #endif	
+#endif
 	pause_sound();
 #ifdef USE_GUICHAN
 	running=true;
@@ -276,7 +278,9 @@ static void goMenu(void)
 	quit_text();
 #endif
 #ifdef USE_UAE4ALL_VKBD
+#ifndef __PSP2__ //no need to reload all the vkbd graphics everytime on Vita
 	vkbd_init();
+#endif
 #endif
     getChanges();
 #ifdef USE_UAE4ALL_VKBD
@@ -598,7 +602,7 @@ void gui_handle_events (void)
 	buttonSelect = SDL_JoystickGetButton(uae4all_joy0, PAD_SELECT);
 	buttonStart = SDL_JoystickGetButton(uae4all_joy0, PAD_START);
 	
-	if(buttonSelect)
+	if(buttonSelect && !buttonStart) //start+select = virtual keyboard vkbd
 	{
 		//re-center the Joysticks when the user opens the menu
 		SDL_JoystickUpdate();
@@ -1700,8 +1704,13 @@ if(!vkbd_mode)
 } // if(!vkbd_mode)
 
 #ifdef USE_UAE4ALL_VKBD
+#ifdef __PSP2__
+	//on Vita Start+Select (in this order) brings up the  virtual keyboard
+	if(buttonStart && buttonSelect)
+#else
 	//L+K: virtual keyboard
 	if(triggerL && keystate[SDLK_k])
+#endif
 	{
 		if(!justLK)
 		{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -186,6 +186,11 @@ void do_start_program (void)
 void do_leave_program (void)
 {
 #ifdef USE_SDL
+#ifdef __PSP2__ //On Vita, only remove keyboard graphics from memory when quitting the emu
+#ifdef USE_UAE4ALL_VKBD
+	vkbd_quit();
+#endif
+#endif
   if(current_screenshot != NULL)
     SDL_FreeSurface(current_screenshot);
 #endif

--- a/src/od-joy.cpp
+++ b/src/od-joy.cpp
@@ -54,6 +54,7 @@ extern int rAnalogY;
 extern int lAnalogX;
 extern int lAnalogY;
 extern int mainMenu_leftStickMouse;
+extern int mainMenu_deadZone;
 #endif
 
 extern char launchDir[300];
@@ -111,7 +112,7 @@ void read_joystick(int nr, unsigned int *dir, int *button)
 	if (((mainMenu_customControls && mainMenu_custom_dpad==2) || gp2xMouseEmuOn))
 #else
 	if (((mainMenu_customControls && mainMenu_custom_dpad==2) || gp2xMouseEmuOn || (triggerL && !triggerR && !gp2xButtonRemappingOn)))
-#endif __PSP2__
+#endif //__PSP2__
 #endif 
 	{
 		if (buttonY)
@@ -183,10 +184,11 @@ void read_joystick(int nr, unsigned int *dir, int *button)
 #ifdef __PSP2__
 	//VITA: always use an analog stick (default: right stick) for mouse pointer movements
 	//here we are using a small deadzone
-	int analogX;
-	int analogY;
+	int analogX=0;
+	int analogY=0;
 		
-	if (mainMenu_leftStickMouse) {
+	if (mainMenu_leftStickMouse)
+	{
 		analogX=lAnalogX;
 		analogY=lAnalogY;
 	}
@@ -195,21 +197,17 @@ void read_joystick(int nr, unsigned int *dir, int *button)
 		analogX=rAnalogX;
 		analogY=rAnalogY;
 	}
-		
-	if (analogX<100 && analogX>-100) 
+	//Deadzone	
+	//max movement is mouseScale.
+	//that way, when in one of the other mouse modes, 
+	//the Y button to change scale still works
+	if (!(analogX<mainMenu_deadZone && analogX>-mainMenu_deadZone)) 
 	{
-		analogX=0;
-	}
-	if (analogY<100 && analogY>-100)
-	{
-		analogY=0;
-	}
-	if (analogX != 0 || analogY != 0 ) 
-	{
-		//max movement is mouseScale.
-		//that way, when in one of the other mouse modes, 
-		//the Y button to change scale still works
 		lastmx += (int) (analogX/32769.0f * mouseScale);
+		newmousecounters=1;
+	}
+	if (!(analogY<mainMenu_deadZone && analogY>-mainMenu_deadZone))
+	{	
 		lastmy += (int) (analogY/32769.0f * mouseScale);
 		newmousecounters=1;
 	}

--- a/src/od-joy.cpp
+++ b/src/od-joy.cpp
@@ -103,16 +103,20 @@ void read_joystick(int nr, unsigned int *dir, int *button)
 	if (mouseScale > (99*16))
 		mouseScale /= 100;
 
-#ifdef USE_UAE4ALL_VKBD
+#if !defined(__PSP2__) && defined(USE_UAE4ALL_VKBD)
 	if (!vkbd_mode && ((mainMenu_customControls && mainMenu_custom_dpad==2) || gp2xMouseEmuOn || (triggerL && !triggerR && !gp2xButtonRemappingOn)))
 #else
-#ifdef __PSP2__
+#if defined(__PSP2__) && defined(USE_UAE4ALL_VKBD)
 	//on Vita, the L trigger is by default mapped to a mousebutton
 	//so remove the hard coded LTrigger here that was enabling the digital mouse
-	if (((mainMenu_customControls && mainMenu_custom_dpad==2) || gp2xMouseEmuOn))
+	if (!vkbd_mode && ((mainMenu_customControls && mainMenu_custom_dpad==2) || gp2xMouseEmuOn))
+#else
+#if defined(__PSP2__)
+	if ((mainMenu_customControls && mainMenu_custom_dpad==2) || gp2xMouseEmuOn)
 #else
 	if (((mainMenu_customControls && mainMenu_custom_dpad==2) || gp2xMouseEmuOn || (triggerL && !triggerR && !gp2xButtonRemappingOn)))
-#endif //__PSP2__
+#endif
+#endif
 #endif 
 	{
 		if (buttonY)
@@ -181,6 +185,9 @@ void read_joystick(int nr, unsigned int *dir, int *button)
 		}
 	}
 
+#ifdef USE_UAE4ALL_VKBD
+	if (!vkbd_mode) {
+#endif
 #ifdef __PSP2__
 	//VITA: always use an analog stick (default: right stick) for mouse pointer movements
 	//here we are using a small deadzone
@@ -212,6 +219,9 @@ void read_joystick(int nr, unsigned int *dir, int *button)
 		newmousecounters=1;
 	}
 #endif //__PSP2__
+#ifdef USE_UAE4ALL_VKBD
+	}
+#endif
 
 #ifdef USE_UAE4ALL_VKBD
 	if(mainMenu_customControls && !vkbd_mode)

--- a/src/vkbd/vkbd.cpp
+++ b/src/vkbd/vkbd.cpp
@@ -4,6 +4,8 @@
 
 #include "vkbd.h"
 
+#define MENU_FILE_BACKGROUND DATA_PREFIX "background.bmp"
+
 #define MIN_VKBD_TIME 100
 
 int vkbd_mode=0;
@@ -12,7 +14,7 @@ SDLKey vkbd_key=(SDLKey)0;
 SDLKey vkbd_button2=(SDLKey)0;
 int vkbd_keysave=-1234567;
 
-#if !defined (DREAMCAST) && !defined (GP2X) && !defined (PSP) && !defined (GIZMONDO)
+#if !defined (DREAMCAST) && !defined (GP2X) && !defined (PSP) && !defined (GIZMONDO) 
 
 int vkbd_init(void) { return 0; }
 void vkbd_init_button2(void) { }
@@ -140,7 +142,6 @@ static t_vkbd_rect vkbd_rect[]=
 	{{ 80,34,10, 5 },84, 8,90,92, SDLK_RCTRL},	// 91
 	{{131,34,12, 5 },86,28,91,93, SDLK_KP0},	// 92
 	{{145,34, 6, 5 },87,29,92,88, SDLK_KP_PERIOD},	// 93
-
 };
 
 void vkbd_init_button2(void)
@@ -148,11 +149,17 @@ void vkbd_init_button2(void)
 	vkbd_button2=(SDLKey)0;
 }
 
-
 int vkbd_init(void)
 {
 	int i;
 	char tmpchar[256];
+#ifdef __PSP2__
+//	if (!vkbd_screen)
+//	{			//vkbd_screen=SDL_CreateRGBSurface(prSDLScreen->flags,prSDLScreen->w,prSDLScreen->h,prSDLScreen->format->BitsPerPixel,prSDLScreen->format->Rmask,prSDLScreen->format->Gmask,prSDLScreen->format->Bmask,prSDLScreen->format->Amask);
+//	}
+	SDL_Surface *tmp=SDL_LoadBMP(DATA_PREFIX "vkbd.bmp");
+//	SDL_Surface *tmp=SDL_LoadBMP("app0:/data/vkbd.bmp");
+#else
 #ifdef GP2X
 	snprintf(tmpchar, 256, "%s/data/vkbd.bmp", launchDir);
 	SDL_Surface *tmp = SDL_LoadBMP(tmpchar);
@@ -163,6 +170,7 @@ int vkbd_init(void)
 	SDL_Surface *tmp=SDL_LoadBMP(DATA_PREFIX "vkbd.bmp");
 #endif
 #endif
+#endif //__PSP2__
 	if (tmp==NULL)
 	{
 		printf("Virtual Keyboard Bitmap Error: %s\n",SDL_GetError());
@@ -174,6 +182,9 @@ int vkbd_init(void)
 		vkey[i]=NULL;
 	for(i=0;i<MAX_KEY;i++)
 	{
+#ifdef __PSP2__
+		snprintf(tmpchar, 256, "app0:/data/key%i.bmp", i);
+#else
 #ifdef GP2X
 		snprintf(tmpchar, 256, "%s/data/key%i.bmp", launchDir, i);
 #else
@@ -183,6 +194,7 @@ int vkbd_init(void)
 		snprintf(tmpchar, 256, DATA_PREFIX "key%i.bmp", i);
 #endif
 #endif
+#endif //__PSP2__
 		tmp=SDL_LoadBMP(tmpchar);
 		if (tmp==NULL)
 			break;
@@ -190,7 +202,9 @@ int vkbd_init(void)
 		SDL_FreeSurface(tmp);
 	}
 	vkbd_actual=0;
+#ifndef __PSP2__ //no need to show keyboard on first startup
 	vkbd_redraw();
+#endif
 	vkbd_mode=0;
 	vkbd_move=0;
 	vkbd_key=(SDLKey)0;
@@ -198,7 +212,6 @@ int vkbd_init(void)
 	vkbd_keysave=-1234567;
 	return 0;
 }
-
 
 void vkbd_quit(void)
 {
@@ -225,10 +238,11 @@ SDLKey vkbd_process(void)
 	Uint32 now=SDL_GetTicks();
 	SDL_Rect r;
 	int canmove=(now-last_time>MIN_VKBD_TIME);
+
 #ifndef VKBD_ALWAYS
-	if (vkbd_move) 
+	if (vkbd_move)
 #endif
-		vkbd_redraw();
+	vkbd_redraw();
 	if (vkbd_move&VKBD_BUTTON)
 	{
 		vkbd_move=0;
@@ -275,5 +289,4 @@ SDLKey vkbd_process(void)
 #endif
 	return (SDLKey)0;
 }
-
 #endif


### PR DESCRIPTION
Complete changelog:
- virtual keyboard (mapped to "hold start then press select") 
- labels in custom control menu now reflect Vita controller
- default analog mouse control deadzone increased from 100 to 1000 to fix mouse pointer drift (can be changed in menu)
- default joystick port set to 1, since the mouse is always on (can be changed in menu)
- added analog joystick deadzone setting
- implemented autocentering to fix mouse pointer drift on some Vitas
- START+DPAD left/right for quick switching between different zoomed screenmodes, useful for games like Chaos Engine. (Use START+DPAD up/down to center screen after quick switching)