### PR TITLE
sticky virtual keyboard keys implemented.

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -49,6 +49,7 @@ VITA-EXCLUSIVE FEATURES:
 - Additional emulator settings: sprite-sprite collisions can be enabled, blitter settings can be changed
 - Adjustable stereo separation
 - Bluetooth keyboard and mouse support
+- Sticky virtual keyboard modifiers: allows keyboard combos like CTRL-C to be entered easily
 
 NOTES:
 
@@ -92,8 +93,11 @@ Dpad = Amiga joystick directions
 
 When custom controls are off:
 L/R shoulder buttons = Mousebuttons
-Square = Joystick button autofire (can be customized)
-X = Joystick button (can be customized)
+(Shown below are control presets 1 (default) / 2 / 3 / 4)
+Square = Autofire (default) / Fire / Autofire / Fire
+Cross = Fire (default) / Autofire / Up (Jump) / Up (Jump) 
+Triangle = Space (default) / Space / Fire / Autofire
+Circle = Secondary Fire (used only in a few games)
 R+Square = Ctrl
 R+Circle = Left Alt
 R+Cross = Help
@@ -108,10 +112,16 @@ Virtual keyboard controls:
 Start = Toggle virtual keyboard
 Right analog stick up/down = Move virtual keyboard up and down
 Right analog stick left/right = Change virtual keyboard transparency
+Cross = Press selected key
 Square = Backspace
-Triangle = Toggle Shift
+Triangle = Toggle shift
+Circle = Turn off all sticky keys (ctrl, alt, amiga, and shift)
 
 CHANGELOG:
+1.57
+
+- Sticky virtual keyboard keys implemented. The alt, ctrl, amiga, and shift virtual keyboard keys are now sticky. Press them once to enable and another time to let go of the key. Key combos like "Amiga-Q" can now be entered using the virtual keyboard. The circle button quickly un-sticks all keys.
+
 1.56
 
 - fix keys being pressed when pressing Vita buttons (introduced in 1.55)

--- a/src/m68k/fame/famec_opcodes.h
+++ b/src/m68k/fame/famec_opcodes.h
@@ -21537,6 +21537,10 @@ OPCODE(0x4E7A)
     EXECUTE_EXCEPTION(M68K_PRIVILEGE_VIOLATION_EX,6);
     
   FETCH_WORD(src);
+
+  if ((src & 0x0FFF) == 3 || ((src & 0x07FF) >= 4 && (src & 0x0FFF) != 0x804))
+    EXECUTE_EXCEPTION(M68K_ILLEGAL_INSTRUCTION_EX,6);
+
   MOVEC2(src & 0x0FFF, src >> 12);
 	RET(6)
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,6 +57,10 @@ extern SDL_Surface *current_screenshot;
 #include "gp2xutil.h"
 #endif
 
+#ifdef USE_UAE4ALL_VKBD
+#include "vkbd.h"
+#endif
+
 #ifdef __PSP2__
 //Allow locking PS Button
 #include <psp2/shellutil.h>
@@ -153,6 +157,9 @@ int quit_program = 0;
 void uae_reset (void)
 {
     gui_purge_events();
+#ifdef USE_UAE4ALL_VKBD
+	vkbd_reset_sticky_keys(); // keyvalues clear on reset, so vkbd must reflect this
+#endif
     black_screen_now();
     quit_program = 2;
     set_special (SPCFLAG_BRK);

--- a/src/od-joy.cpp
+++ b/src/od-joy.cpp
@@ -551,6 +551,12 @@ void read_joystick(int nr, unsigned int *dir, int *button)
 				buttonA[0] = 0;
 				*button = 0;
 			}
+			else if (buttonB[0])
+			{
+				vkbd_move=VKBD_BUTTON_RESET_STICKY;
+				buttonB[0] = 0;
+				*button = 0;
+			}
 #else // in other cases where those buttons might not be available, use the amiga joystick
 			if (*button || buttonX[0] )
 			{
@@ -559,9 +565,11 @@ void read_joystick(int nr, unsigned int *dir, int *button)
 				*button = 0;
 			}
 #endif
-			else //button release, make shift toggle possible again.
-			{
-				vkbd_can_switch_shift=1;
+			else { //button release, pressing sticky keys is possible again.
+				for (int i=0; i<NUM_STICKY; i++)
+				{
+					vkbd_sticky_key[i].can_switch=true;
+				}
 			}
 			// TODO: add vkbd_button2 mapped to button2
 		}

--- a/src/vkbd/vkbd.h
+++ b/src/vkbd/vkbd.h
@@ -1,16 +1,25 @@
+#ifndef VKBD_H
+#define VKBD_H
 #include<SDL.h>
 
 #define VKBD_X 20
 #define VKBD_Y 200
 
-#define VKBD_LEFT	1
-#define VKBD_RIGHT	2	
-#define VKBD_UP		4
-#define VKBD_DOWN	8
-#define VKBD_BUTTON	16
-#define VKBD_BUTTON_BACKSPACE	32
-#define VKBD_BUTTON_SHIFT	64
+#define VKBD_LEFT 1
+#define VKBD_RIGHT 2	
+#define VKBD_UP 4
+#define VKBD_DOWN 8
+#define VKBD_BUTTON 16
+#define VKBD_BUTTON_BACKSPACE 32
+#define VKBD_BUTTON_SHIFT 64
+#define VKBD_BUTTON_RESET_STICKY 128
 #define VLBD_BUTTON2 128
+
+// special return codes for vkbd_process
+#define KEYCODE_NOTHING -1234567
+#define KEYCODE_STICKY_RESET -100
+
+#define NUM_STICKY 7 // number of sticky keys (shift, alt etc)
 
 int vkbd_init(void);
 void vkbd_quit(void);
@@ -21,12 +30,20 @@ void vkbd_displace_up(void);
 void vkbd_displace_down(void);
 void vkbd_transparency_up(void);
 void vkbd_transparency_down(void);
+void vkbd_reset_sticky_keys(void);
 
 extern int vkbd_mode;
 extern int vkbd_move;
-extern int vkbd_shift;
-extern int vkbd_can_switch_shift;
+typedef struct
+{
+	int code; // amiga-side keycode
+	bool stuck; // is it currently stuck pressed?
+	bool can_switch; // de-bounce
+	unsigned char index; // index in vkbd_rect[]
+} t_vkbd_sticky_key;
+extern t_vkbd_sticky_key vkbd_sticky_key[NUM_STICKY];
 extern int vkbd_key;
 extern int vkbd_keysave;
 extern SDLKey vkbd_button2;
 extern int keymappings[10][3];
+#endif // VKBD_H


### PR DESCRIPTION
The alt, ctrl, amiga, and shift virtual keyboard keys are now sticky. Press them once to enable and another time to let go of the key. Key combos like "Amiga-Q" can now be entered using the virtual keyboard. The circle button quickly un-sticks all keys.